### PR TITLE
Fix broken openmaps endpoint

### DIFF
--- a/queries.py
+++ b/queries.py
@@ -5,7 +5,7 @@ import requests
 def get_coordinates(city):
     """Gets the coordinate bounds of a city from OpenStreetMap."""
 
-    url = "https://nominatim.openstreetmap.org/search?q=" + city + "&format=json&country=Canada"
+    url = "https://nominatim.openstreetmap.org/search?q=" + city + "&format=json"
     response = requests.get(url=url, timeout=10)
     response.raise_for_status()
     data = response.json()


### PR DESCRIPTION
The openstreetmap endpoint doesn't support both `q=` and `country=`. I'm just removing `&country=Canada` to fix the query.